### PR TITLE
Investigate application crash logs

### DIFF
--- a/crash_fix_summary.md
+++ b/crash_fix_summary.md
@@ -1,0 +1,139 @@
+# PicoTTS Crash Fix Summary - July 14, 2025
+
+## Issue Summary
+PicoTTS was experiencing SIGSEGV crashes in `picobase_get_next_utf8char` function when processing UTF-8 characters. The crash manifested with different fault addresses and offsets, indicating memory access violations during UTF-8 character parsing.
+
+## Applied Fixes
+
+### 1. Enhanced Input Validation in `picobase_get_next_utf8char`
+
+**File**: `pico/lib/picobase.c` (lines 954-995)
+
+**Changes Applied**:
+- Added comprehensive NULL pointer checks for all input parameters
+- Added bounds checking before accessing `utf8s[*pos]`
+- Added validation for invalid UTF-8 length (len == 0)
+- Enhanced the character copying loop with bounds checking
+- Added check for incomplete character parsing
+
+**Key Improvements**:
+```c
+/* Enhanced loop with bounds checking */
+while ((i < len) && (poscnt < utf8slenmax) && (utf8s[poscnt] != 0)) {
+    utf8char[i] = utf8s[poscnt];
+    poscnt++;
+    i++;
+}
+
+/* Check if we completed the character successfully */
+if (i < len) {
+    return FALSE;  /* Incomplete character */
+}
+```
+
+### 2. Defensive Programming in Calling Functions
+
+**File**: `pico/lib/picopr.c` (lines 620-655)
+
+**Changes Applied**:
+- Added NULL check in `tok_tokenDigitStrToInt` function
+- Added error handling for `picobase_get_next_utf8char` failures
+- Graceful loop termination on parsing errors
+
+## Crash Analysis Details
+
+### Original Crash (Offset +10)
+- **Fault Address**: `0x5f99d67c`
+- **Location**: Early in function during initial UTF-8 access
+- **Cause**: Lack of input validation
+
+### Recent Crash (Offset +26)  
+- **Fault Address**: `0x607dd69c`
+- **Location**: Later in function during character copying loop
+- **Cause**: Insufficient bounds checking in loop iteration
+
+## Technical Specifications
+
+### Constants Used
+- `PICOBASE_UTF8_MAXLEN = 4` (maximum UTF-8 character length)
+- `PR_MAX_DATA_LEN` (defined as input buffer size)
+
+### Return Value Behavior
+- **TRUE**: Successfully parsed UTF-8 character
+- **FALSE**: Error condition (NULL input, bounds violation, incomplete character)
+
+## Testing Recommendations
+
+### Immediate Testing
+1. **Regression Testing**: Verify TTS synthesis still works correctly
+2. **Boundary Testing**: Test with empty strings, maximum length strings
+3. **Invalid Input Testing**: Test with NULL parameters, malformed UTF-8
+
+### Comprehensive Testing
+```bash
+# Build with enhanced debugging
+LOCAL_CFLAGS += -DDEBUG_UTF8_PARSING
+
+# Test cases to implement
+1. NULL pointer inputs
+2. Empty string inputs  
+3. Strings with invalid UTF-8 sequences
+4. Very long input strings
+5. Strings with mixed ASCII and UTF-8 characters
+6. Boundary condition strings (exactly at buffer limits)
+```
+
+### Memory Safety Testing
+- Run with AddressSanitizer if available
+- Use Valgrind for memory error detection
+- Enable additional runtime checks during development
+
+## Expected Outcomes
+
+### Positive Results
+- No more SIGSEGV crashes in `picobase_get_next_utf8char`
+- Graceful handling of invalid input data
+- Maintained TTS functionality for valid inputs
+
+### Performance Impact
+- Minimal overhead from additional bounds checking
+- No functional changes for valid input scenarios
+- Improved robustness in error conditions
+
+## Monitoring and Follow-up
+
+### Crash Monitoring
+- Monitor for any remaining crashes in UTF-8 processing
+- Track different fault addresses if crashes persist
+- Analyze call stacks for patterns
+
+### Performance Monitoring  
+- Verify TTS synthesis speed is maintained
+- Check memory usage patterns
+- Monitor for any new error conditions
+
+## Rollback Plan
+
+If issues arise, the changes can be reverted by:
+1. Removing enhanced bounds checking in the loop
+2. Reverting to original input validation approach
+3. Restoring original error handling logic
+
+The fixes are designed to be conservative and maintain backward compatibility while adding safety measures.
+
+## Risk Assessment: LOW
+
+- Changes only add defensive programming
+- No modification of core TTS algorithms
+- Maintains existing API contracts
+- Follows established error handling patterns
+- Comprehensive input validation prevents undefined behavior
+
+## Next Steps
+
+1. **Deploy**: Test the fixed version in the target environment
+2. **Monitor**: Watch for crash reports and performance metrics
+3. **Validate**: Confirm TTS functionality works as expected
+4. **Document**: Update any relevant technical documentation
+
+The enhanced fixes should resolve the reported SIGSEGV crashes while maintaining full TTS functionality.

--- a/pico/lib/picobase.c
+++ b/pico/lib/picobase.c
@@ -960,7 +960,7 @@ picoos_uint8 picobase_get_next_utf8char(const picoos_uint8 *utf8s,
     picoos_uint8 len;
     picoos_uint32 poscnt;
 
-    /* Add input validation to prevent crashes */
+    /* Enhanced input validation to prevent crashes */
     if (utf8s == NULL || pos == NULL || utf8char == NULL) {
         if (utf8char != NULL) utf8char[0] = 0;
         return FALSE;
@@ -975,21 +975,27 @@ picoos_uint8 picobase_get_next_utf8char(const picoos_uint8 *utf8s,
     utf8char[0] = 0;
     len = picobase_det_utf8_length(utf8s[*pos]);
     if ((((*pos) + len) > utf8slenmax) ||
-        (len > PICOBASE_UTF8_MAXLEN)) {
+        (len > PICOBASE_UTF8_MAXLEN) ||
+        (len == 0)) {  /* Additional check for invalid UTF-8 */
         return FALSE;
     }
 
     poscnt = *pos;
     i = 0;
-    while ((i < len) && (utf8s[poscnt] != 0)) {
+    /* Enhanced loop with bounds checking to prevent accessing invalid memory */
+    while ((i < len) && (poscnt < utf8slenmax) && (utf8s[poscnt] != 0)) {
         utf8char[i] = utf8s[poscnt];
         poscnt++;
         i++;
     }
+    
     utf8char[i] = 0;
-    if ((i < len) && (utf8s[poscnt] == 0)) {
-        return FALSE;
+    
+    /* Check if we completed the character successfully */
+    if (i < len) {
+        return FALSE;  /* Incomplete character */
     }
+    
     *pos = poscnt;
     return TRUE;
 }


### PR DESCRIPTION
Enhance UTF-8 character parsing in PicoTTS to fix a SIGSEGV crash.

The crash in `picobase_get_next_utf8char` initially occurred at offset `+10` due to basic input validation issues. After addressing those, the crash shifted to offset `+26` within the character copying loop, indicating a need for more robust bounds checking during UTF-8 character iteration. This PR adds comprehensive input and loop bounds validation to prevent memory access violations.